### PR TITLE
Removed body.addClass(OPENED_MODAL_CLASS)

### DIFF
--- a/angular-foundation.js
+++ b/angular-foundation.js
@@ -677,9 +677,7 @@ angular.module('mm.foundation.modal', ['mm.foundation.mediaQueries'])
                 fixedPositiong = false;
             }
         }
-        if (fixedPositiong) {
-            body.addClass(OPENED_MODAL_CLASS);
-        } else {
+        if (!fixedPositiong) {
             body.removeClass(OPENED_MODAL_CLASS);
         }
     }


### PR DESCRIPTION
The condition always triggers whenever a modal is closed.