### PR TITLE
Autofocus the modal dialog

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -294,6 +294,9 @@ angular.module('mm.foundation.modal', ['mm.foundation.mediaQueries'])
             // This allows for scrolling
             options.scope.$watch(() => modalDomEl[0].offsetHeight, resizeHandler);
 
+			const focusedElem = (modalDomEl[0].querySelector('[autofocus]') || modalDomEl[0]);
+			focusedElem.focus();
+
             return $q.all(promises);
         });
     };

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -294,8 +294,10 @@ angular.module('mm.foundation.modal', ['mm.foundation.mediaQueries'])
             // This allows for scrolling
             options.scope.$watch(() => modalDomEl[0].offsetHeight, resizeHandler);
 
-			const focusedElem = (modalDomEl[0].querySelector('[autofocus]') || modalDomEl[0]);
-			focusedElem.focus();
+			promises.push($q(function () {
+				const focusedElem = (modalDomEl[0].querySelector('[autofocus]') || modalDomEl[0]);
+				focusedElem.focus();
+			}));
 
             return $q.all(promises);
         });

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -294,12 +294,10 @@ angular.module('mm.foundation.modal', ['mm.foundation.mediaQueries'])
             // This allows for scrolling
             options.scope.$watch(() => modalDomEl[0].offsetHeight, resizeHandler);
 
-			promises.push($q(function () {
-				const focusedElem = (modalDomEl[0].querySelector('[autofocus]') || modalDomEl[0]);
-				focusedElem.focus();
-			}));
-
-            return $q.all(promises);
+            return $q.all(promises).then(function () {
+			    const focusedElem = (modalDomEl[0].querySelector('[autofocus]') || modalDomEl[0]);
+			    focusedElem.focus();
+			});
         });
     };
 


### PR DESCRIPTION
Hey,

I propose you to automatically focus the first control with autofocus attribute or fallback to dialog itself.
In any case, when a modal form opens, I want to give it the focus otherwise tabbing will cycle through the back window.