### PR TITLE
feat(tooltip): Multiple trigger support + close on esc

### DIFF
--- a/src/tooltip/docs/readme.md
+++ b/src/tooltip/docs/readme.md
@@ -14,7 +14,7 @@ will display:
   "bottom", "left", "right".
 - `tooltip-popup-delay`: For how long should the user have to have the mouse
   over the element before the tooltip shows (in milliseconds)? Defaults to 0.
-- `tooltip-trigger`: What should trigger a show of the tooltip?
+- `tooltip-trigger`: What should trigger a show of the tooltip? Supports a space separated list of event names
 - `tooltip-append-to-body`: Should the tooltip be appended to `$body` instead of
   the parent element?
 

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -332,8 +332,12 @@ angular.module('mm.foundation.tooltip', ['mm.foundation.position', 'mm.foundatio
                                     element.bind(hideTrigger, hideTooltipBind);
                                 }
                             });
+                            element.on('keydown', function (e) {
+                                if (e.which === 27) {
+                                    hideTooltipBind();
+                                }
+                            });
                         });
-
 
                         attrs.$observe(prefix + 'AppendToBody', function(val) {
                             appendToBody = angular.isDefined(val) ? $parse(val)(scope) : appendToBody;


### PR DESCRIPTION
* Added multiple trigger support (so you can have both `focus` and `mouseover` triggers on the same tooltip)
* Added close on `esc` support

Both of these help improve accessibility when used with `ngAria` and were influenced by `angular-ui/bootstrap` changes that haven't been ported over yet.