### PR TITLE
Fixing Content Floating for Vertical Tabs

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -84,7 +84,7 @@ angular.module('mm.foundation.tabs', [])
         },
         controller: 'TabsetController',
         templateUrl: function(elem, attr) {
-            var type = attr.vertical == 'true' ? 'vertical' : 'horizontal';
+            var type = attr.vertical == 'vertical' ? 'vertical' : 'horizontal';
             return 'template/tabs/tabset-' + type + '.html';
         },
         link: function(scope, element, attrs) {

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -83,7 +83,10 @@ angular.module('mm.foundation.tabs', [])
             openOnLoad: '=?'
         },
         controller: 'TabsetController',
-        templateUrl: 'template/tabs/tabset.html',
+        templateUrl: function(elem, attr) {
+            var type = attr.vertical == 'true' ? 'vertical' : 'horizontal';
+            return 'template/tabs/tabset-' + type + '.html';
+        },
         link: function(scope, element, attrs) {
             scope.vertical = angular.isDefined(attrs.vertical) ? scope.$parent.$eval(attrs.vertical) : false;
             scope.justified = angular.isDefined(attrs.justified) ? scope.$parent.$eval(attrs.justified) : false;

--- a/src/tabs/tabset-horizontal.html
+++ b/src/tabs/tabset-horizontal.html
@@ -1,6 +1,6 @@
 <div class="tabbable">
-  <ul class="tabs" ng-class="{'vertical': vertical}" ng-transclude></ul>
-  <div class="tabs-content" ng-class="{'vertical': vertical}">
+  <ul class="tabs" ng-transclude></ul>
+  <div class="tabs-content">
     <div class="tabs-panel"
       ng-repeat="tab in tabs"
       ng-class="{'is-active': tab.active}">

--- a/src/tabs/tabset-vertical.html
+++ b/src/tabs/tabset-vertical.html
@@ -1,0 +1,14 @@
+<div class="tabbable row collapse">
+  <div class="medium-3 columns">
+    <ul class="tabs vertical" ng-transclude></ul>
+  </div>
+  <div class="medium-9 columns">
+    <div class="tabs-content vertical">
+      <div class="tabs-panel"
+        ng-repeat="tab in tabs"
+        ng-class="{'is-active': tab.active}">
+        <div tab-content-transclude="tab"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -522,8 +522,20 @@ describe('tabs', function() {
             scope.$apply();
         }));
 
-        it('to show tabs vertically', function() {
-            expect(angular.element(elm[0].querySelectorAll('ul.tabs'))).toHaveClass('vertical');
+        it('to show tab headers vertically', function() {
+            var headers = angular.element(elm[0].querySelectorAll('ul.tabs'));
+
+            expect(headers).toHaveClass('vertical');
+            expect(headers.parent()).toHaveClass('medium-3');
+            expect(headers.parent()).toHaveClass('columns')
+        });
+
+        it('to show tab panels vertically', function() {
+            var content = angular.element(elm[0].querySelectorAll('div.tabs-content'));
+
+            expect(content).toHaveClass('vertical');
+            expect(content.parent()).toHaveClass('medium-9');
+            expect(content.parent()).toHaveClass('columns')
         });
     });
 

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -3,14 +3,15 @@ import mocks from "angular-mocks";
 
 import "src/tabs/tabs.js"
 import "src/tabs/tab.html.js"
-import "src/tabs/tabset.html.js"
+import "src/tabs/tabset-horizontal.html.js"
+import "src/tabs/tabset-vertical.html.js"
 
 describe('tabs', function() {
 
     var inject = mocks.inject;
     var module = mocks.module;
 
-    beforeEach(module('mm.foundation.tabs', 'template/tabs/tabset.html', 'template/tabs/tab.html'));
+    beforeEach(module('mm.foundation.tabs', 'template/tabs/tabset-horizontal.html', 'template/tabs/tabset-vertical.html', 'template/tabs/tab.html'));
 
     var elm;
     var scope;


### PR DESCRIPTION
Fixes #28.

Updates the templates for the tabs directive to use the floating columns classes provided by foundation.

- existing template converted to horizontal layout for tabs
- new template added for vertical layout for tabs using floating columns
  - this is the format [recommended by foundation](https://foundation.zurb.com/sites/docs/tabs.html)
- new tests added to check for floating columns classes on vertical tab configuration