### PR TITLE
Fixing Tabs Vertical Attribute to True/False

### DIFF
--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -84,7 +84,7 @@ angular.module('mm.foundation.tabs', [])
         },
         controller: 'TabsetController',
         templateUrl: function(elem, attr) {
-            var type = attr.vertical == 'vertical' ? 'vertical' : 'horizontal';
+            var type = attr.vertical == 'true' ? 'vertical' : 'horizontal';
             return 'template/tabs/tabset-' + type + '.html';
         },
         link: function(scope, element, attrs) {

--- a/src/tabs/test/tabs.spec.js
+++ b/src/tabs/test/tabs.spec.js
@@ -519,7 +519,7 @@ describe('tabs', function() {
         beforeEach(inject(function($compile, $rootScope) {
             scope = $rootScope.$new();
             scope.vertical = true;
-            elm = $compile('<tabset vertical="vertical"></tabset>')(scope);
+            elm = $compile('<tabset vertical="true"></tabset>')(scope);
             scope.$apply();
         }));
 


### PR DESCRIPTION
Fixes #36.

Minor fix to tabs. Changes:
- test setup to use `vertical='true'` (the correct setup) instead of `vertical='vertical'`
- updates the directive to check for `vertical='true'` instead of `vertical='vertical'`