### PR TITLE
feat(drilldownMenu): Add automatic resizing, an API, and events.

### DIFF
--- a/src/drilldownMenu/docs/demo.html
+++ b/src/drilldownMenu/docs/demo.html
@@ -31,13 +31,14 @@
         </ul>
       </li>
       <li>
-        <a href="#">Item 2</a>
+        <a href="#">Search Engines</a>
         <ul class="menu">
-          <li><a href="#">Item 2A</a></li>
-          <li><a href="#">Item 2B</a></li>
+          <li><a href="https://www.google.com/">Google</a></li>
+          <li><a href="https://www.bing.com/">Bing</a></li>
+          <li><a href="https://www.duckduckgo.com/">DuckDuckGo</a></li>
         </ul>
       </li>
-      <li><a href="#">Item 3</a></li>
+      <li><a href="http://foundation.zurb.com/">Foundation</a></li>
       <li><a href="#">Item 4</a></li>
     </ul>
   </div>

--- a/src/drilldownMenu/docs/demo.html
+++ b/src/drilldownMenu/docs/demo.html
@@ -1,67 +1,115 @@
 <div ng-controller="DrillDownDemoCtrl">
-  <h4>Auto `Wrapper` and `Back` Links</h4>
-  <ul class="drilldown menu" drilldown-menu>
-    <li>
-      <a>Item 1</a>
-      <ul class="menu">
-        <li><a href="#">Item 1A</a></li>
-        <li>
-          <a href="#">Item 1B</a>
-          <ul class="menu">
-            <li><a href="#">Item 1B i</a></li>
-            <li><a href="#">Item 1B ii</a></li>
-            <li>
-              <a href="#">Item 1B iii</a>
-              <ul class="menu">
-                <li><a href="#">Item 1B iii alpha</a></li>
-                <li><a href="#">Item 1B iii omega</a></li>
-              </ul>
-            </li>
-            <li>
-              <a href="#">Item 1B iv</a>
-              <ul class="menu">
-                <li><a href="#">Item 1B iv alpha</a></li>
-              </ul>
-            </li>
-          </ul>
-        </li>
-        <li><a href="#">Item 1C</a></li>
-      </ul>
-    </li>
-    <li>
-      <a href="#">Item 2</a>
-      <ul class="menu">
-        <li><a href="#">Item 2A</a></li>
-        <li><a href="#">Item 2B</a></li>
-      </ul>
-    </li>
-    <li><a href="#">Item 3</a></li>
-    <li><a href="#">Item 4</a></li>
-  </ul>
-
-  <!-- Manual Wrapper and Back Links -->
-  <h4>Manual `Wrapper` and `Back` Links</h4>
-  <!-- Manually added wrapper MUST be `div` with class `is-drilldown` -->
-  <div class="is-drilldown">
+  <div class="callout">
+    <h4>Auto `Wrapper` and `Back` Links</h4>
     <ul class="drilldown menu" drilldown-menu>
+
       <li>
         <a>Item 1</a>
         <ul class="menu">
-          <!-- Manual back link MUST be `li` with class `.js-drilldown-back` -->
-          <li class="js-drilldown-back"><a href="#">Manual Back To Top</a></li>
           <li><a href="#">Item 1A</a></li>
           <li>
             <a href="#">Item 1B</a>
             <ul class="menu">
-              <li class="js-drilldown-back"><a href="#">Manual Back To Level 1</a></li>
-              <li><a href="#">Item 1B i</a></li>
+              <li><a href="#">Item 1B i make this really long so that it will overflow a line</a></li>
               <li><a href="#">Item 1B ii</a></li>
+              <li>
+                <a href="#">Item 1B iii - this one is also extended to overflow a line</a>
+                <ul class="menu">
+                  <li><a href="#">Item 1B iii alpha</a></li>
+                  <li><a href="#">Item 1B iii omega</a></li>
+                </ul>
+              </li>
+              <li>
+                <a href="#">Item 1B iv</a>
+                <ul class="menu">
+                  <li><a href="#">Item 1B iv alpha</a></li>
+                </ul>
+              </li>
             </ul>
           </li>
           <li><a href="#">Item 1C</a></li>
         </ul>
       </li>
-      <li><a href="#">Item 2</a></li>
+      <li>
+        <a href="#">Item 2</a>
+        <ul class="menu">
+          <li><a href="#">Item 2A</a></li>
+          <li><a href="#">Item 2B</a></li>
+        </ul>
+      </li>
+      <li><a href="#">Item 3</a></li>
+      <li><a href="#">Item 4</a></li>
     </ul>
   </div>
+
+  <div class="callout">
+
+    <!-- Manual Wrapper and Back Links -->
+    <h4>Manual `Wrapper` and `Back` Links</h4>
+    <!-- Manually added wrapper MUST be `div` with class `is-drilldown` -->
+    <div class="is-drilldown">
+      <ul class="drilldown menu" drilldown-menu>
+        <li>
+          <a>Item 1</a>
+          <ul class="menu">
+            <!-- Manual back link MUST be `li` with class `.js-drilldown-back` -->
+            <li class="js-drilldown-back"><a href="#">Manual Back To Top</a></li>
+            <li><a href="#">Item 1A</a></li>
+            <li>
+              <a href="#">Item 1B</a>
+              <ul class="menu">
+                <li class="js-drilldown-back"><a href="#">Manual Back To Level 1</a></li>
+                <li><a href="#">Item 1B i</a></li>
+                <li><a href="#">Item 1B ii</a></li>
+              </ul>
+            </li>
+            <li><a href="#">Item 1C</a></li>
+          </ul>
+        </li>
+        <li><a href="#">Item 2</a></li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="callout" id="drilldown-api">
+
+    <!-- API usage -->
+    <h4>API Usage</h4>
+    <alert ng-repeat="alert in vm.alerts" type="alert.type" close="vm.closeAlert($index)">
+      {{alert.msg}}
+    </alert>
+
+    <div>
+      <button class="button" ng-click="vm.showHideMenu()">Show / Hide the Menu</button>
+      <button class="button" ng-click="vm.ddmApi.resizeMenu()" ng-show="vm.haveShown">Resize</button>
+    </div>
+
+    <div class="callout ng-hide" ng-show="vm.shouldShow">
+      <ul class="drilldown menu" id="drilldown-api-menu" drilldown-menu drilldown-menu-api="vm.ddmApi">
+        <li>
+          <a href="#">Item 1</a>
+          <ul class="menu" id="drilldown-api-submenu-1">
+            <li><a href="#">Item 1A</a></li>
+            <li>
+              <a href="#">Item 1B</a>
+              <ul class="menu">
+                <li><a href="#">Item 1B i</a></li>
+                <li><a href="#">Item 1B ii</a></li>
+              </ul>
+            </li>
+            <li><a href="#">Item 1C</a></li>
+          </ul>
+        </li>
+        <li><a href="#">Item 2</a></li>
+      </ul>
+
+      <div ng-show="vm.haveResized">
+        <h5>Other API functions</h5>
+        <button class="button" ng-click="vm.showSubmenu1()">Open Submenu 1</button>
+        <button class="button" ng-click="vm.hideSubmenu1()">Close Submenu 1</button>
+        <button class="button" ng-click="vm.ddmApi.hideAll()">Close All Submenus</button>
+      </div>
+    </div>
+  </div>
+
 </div>

--- a/src/drilldownMenu/docs/demo.js
+++ b/src/drilldownMenu/docs/demo.js
@@ -1,3 +1,164 @@
-angular.module('foundationDemoApp').controller('DrillDownDemoCtrl', function ($scope) {
+angular.module('foundationDemoApp')
+.controller('DrillDownDemoCtrl', function($scope, $element, $timeout, $log) {
+    'ngInject';
+    const vm = {
+        ddmApi: null,
+        shouldShow: false,
+        haveShown: false,
+        haveResized: false,
+        alerts: [],
 
+        showHideMenu: showHideMenu,
+
+        showSubmenu1: showSubmenu1,
+        hideSubmenu1: hideSubmenu1,
+
+        closeAlert: closeAlert,
+    };
+    $scope.vm = vm;
+
+    /**
+     * Initial alert used as part of the API Usage demo
+     */
+    vm.alerts = [{
+        type: 'alert',
+        msg: 'The menu below is hidden with css. Press the button to show it (using ng-show).',
+    }];
+
+    /**
+     * Event handlers for the menu events
+     */
+    $scope.$on('resize.mm.foundation.drilldownMenu', onMenuResized);
+    $scope.$on('open.mm.foundation.drilldownMenu', onSubmenuOpen);
+    $scope.$on('hide.mm.foundation.drilldownMenu', onSubmenuClosed);
+
+    /**
+     * Sets the variable to show or hide the menu block
+     */
+    function showHideMenu() {
+        vm.shouldShow = !vm.shouldShow;
+
+        if (!vm.haveShown) {
+            closeAlert(0);
+            addAlert(
+                'alert',
+                'The menu is now "shown", but because it was hidden initially it will start with ' +
+                '"max-width: 0px" and doesn\'t appear! Press the resize button to trigger ' +
+                'a resize via the API'
+            );
+            vm.haveShown = true;
+        }
+    }
+
+    /**
+     * Get the UL for submenu 1.
+     * NOTE: You MUST use the UL for the submenu to show/hide, NOT the parent LI!
+     *
+     * @returns {angular.element}   - The element for submenu 1 in the API section
+     */
+    function getSubmenu1() {
+        return angular.element($element[0].querySelector('ul#drilldown-api-submenu-1'));
+    }
+
+    /**
+     * Function to use the API to open a specific menu item
+     */
+    function showSubmenu1() {
+        //
+        // Find the item
+        //
+        var element = getSubmenu1();
+
+        //
+        // Use the API to open it
+        //
+        vm.ddmApi.show(element);
+    }
+
+    /**
+     * Function to use the API to close a specific menu item
+     */
+    function hideSubmenu1() {
+        //
+        // Find the item
+        //
+        var element = getSubmenu1();
+
+        //
+        // Use the API to open it
+        //
+        vm.ddmApi.hide(element);
+    }
+
+    /**
+     * Handler for the resized event from the menu
+     *
+     * @param {Object} event                - Angular `event` object (see $rootScope.$on)
+     * @param {angular.element} menuElement - The root element of the menu
+     */
+    function onMenuResized(event, menuElement) {
+        if (menuElement.attr('id') !== 'drilldown-api-menu') {
+            return; // One of the other menus
+        }
+        if (vm.haveShown && !vm.haveResized) {
+            closeAlert(0);
+            addAlert(
+                'success',
+                'Congratulations! The menu should now be visible!'
+            );
+            addAlert(
+                'alert',
+                'The same 0-width problem will happen again if the menu is hidden then ' +
+                'resized (via the API or via a viewport size change). ' +
+                'You MUST trigger a resize via the API after showing it again if this happens.'
+            );
+            vm.haveResized = true;
+        }
+    }
+
+    /**
+     * Example handler for the submenu open event
+     *
+     * @param {Object} event                    - Angular `event` object (see $rootScope.$on)
+     * @param {angular.element} menuElement     - The root element of the menu
+     * @param {angular.element} submenuElement  - The submenu element that has just opened
+     */
+    function onSubmenuOpen(event, menuElement, submenuElement) {
+        if (submenuElement.attr('id') === 'drilldown-api-submenu-1') {
+            $log.log('Submenu 1 has been opened!');
+        }
+    }
+
+    /**
+     * Example handler for the submenu close event
+     *
+     * @param {Object} event                    - Angular `event` object (see $rootScope.$on)
+     * @param {angular.element} menuElement     - The root element of the menu
+     * @param {angular.element} submenuElement  - The submenu element that has just closed
+     */
+    function onSubmenuClosed(event, menuElement, submenuElement) {
+        if (submenuElement.attr('id') === 'drilldown-api-submenu-1') {
+            $log.log('Submenu 1 has been closed!');
+        }
+    }
+
+    /**
+     * Closes the specific alert
+     *
+     * @param {number} index    - The index of the alert to close
+     */
+    function closeAlert(index) {
+        vm.alerts.splice(index, 1);
+    }
+
+    /**
+     * Adds a new alert programmatically.
+     * Used of the explanations of the drilldown menu API and functionality.
+     *
+     * @param {string} type     - the type of alert
+     * @param {string} msg      - the alert message
+     */
+    function addAlert(type, msg) {
+        vm.alerts.push({ type: type, msg: msg });
+    }
 });

--- a/src/drilldownMenu/docs/readme.md
+++ b/src/drilldownMenu/docs/readme.md
@@ -2,18 +2,55 @@ A directive that provides the [Foundation Drilldown Menu](http://foundation.zurb
 
 The directive relies on the same markup as the original Foundation Drilldown Menu. It implements some, but not all of the features of the Foundation Drilldown Menu.
 
-#### Implemented:
-- Automatically add a wrapper div around the menu, _if not already provided in the html_
-- Automatically add _back_ entries to the top of submenus, _if not already provided in the html_
-- Wrapper div sized to the min-height required to show the largest sub-menu
+See the demo page for example on how to use this and visit the [Foundation docs](http://foundation.zurb.com/sites/docs/drilldown-menu.html) for more details.
+
+#### Supported Features:
+- Automatically add a wrapper div around the menu, _if not already provided in the html_.
+- Automatically add _back_ entries to the top of submenus, _if not already provided in the html_.
+- Wrapper div sized to the min-height required to show the largest sub-menu.
+  - Automatically resizes as the viewport size changes.
+  - WARNING: show/hide via `ng-show` or similar **DOES NOT** cause a resize.  See notes below.
+- API exposed via `drilldown-menu-api` two-way binding.
+- Events `emit`-ed on the $scope (i.e. upwards towards parent scopes).
+
+#### API
+The API for programmatic control of the drilldown menu is exposed to the parent
+scope via the `drilldown-menu-api` two-way binding. See the 3rd example html and
+associated js for an example.
+
+The available methods are:
+- `resizeMenu()` to trigger a resize.
+- `show(element)` to show the submenu under the given _angular.element_.
+- `hide(element)` to hide the submenu under the given _angular.element_.
+- `hideAll()` to collapse all submenus.
+
+#### Events
+The controller `emit-s` events on the $scope (i.e. upwards towards the parent scope).  The available events are similarly named to the Foundation for Sites equivalents.
+- `'resize.mm.foundation.drilldownMenu'` when the menu resizes. The event listener function format is `function(event, menuElement)`:
+    - `event` - Standard [Angular `event` object](https://code.angularjs.org/1.6.5/docs/api/ng/type/$rootScope.Scope#$on)
+    - `menuElement` - [angular.element](https://code.angularjs.org/1.6.5/docs/api/ng/function/angular.element) for the top level _UL_ element of the menu.
+- `'open.mm.foundation.drilldownMenu'` when a submenu is opened. The event listener function format is `function(event, menuElement, submenuElement)`:
+    - `event` - Standard [Angular `event` object](https://code.angularjs.org/1.6.5/docs/api/ng/type/$rootScope.Scope#$on)
+    - `menuElement` - [angular.element](https://code.angularjs.org/1.6.5/docs/api/ng/function/angular.element) for the top level _UL_ element of the menu.
+    - `submenuElement` - [angular.element](https://code.angularjs.org/1.6.5/docs/api/ng/function/angular.element) for the _UL_ element at the top of the submenu that has just been opened.
+- `'hide.mm.foundation.drilldownMenu'` when a submenu is closed. The event listener function format is `function(event, menuElement, submenuElement)` as above.
+
+#### Usage Notes
+Be careful when dynamically showing and hiding this component.  The component only resizes when created, when the viewport size changes, or when the resize() API is triggered. If it is hidden via css when created it will initialse with 0 height and width.  If it is then shown (using `ng-show` or similar), it will remain as 0 height and width and thus not appear to be visible!
+
+This can be resolved by using the API to resize as part of the reveal.
+
+Alternatively, use `ng-if` instead of `ng-show`.  This re-creates the component when showing, and
+thus the size is set correctly as part of the initialisation.
 
 #### NOT implemented:
-- _back_ entries at the bottom of submenus
-- templates for auto-added _back_ entries
-- `autoHeight`
-- `ScrollTop`
+The following features of the Foundation Drilldown Menu are NOT implemented:
+- _back_ entries at the bottom of submenus.
+- templates for auto-added _back_ entries.
+- `autoHeight`.
+- `ScrollTop`.
 - Handling of keyboard events (up/down/etc.)
-- Automatic addition of aria attributes
-- Any of the plugin options, events, or methods
-
-See the demo page for example on how to use this and visit the [Foundation docs](http://foundation.zurb.com/sites/docs/drilldown-menu.html) for more details.
+- Automatic addition of aria attributes.
+- Any of the plugin options.
+- `scrollme` and `closed` events.
+- `_scrollTop` and `_destroy` methods.

--- a/src/drilldownMenu/drilldownMenu.js
+++ b/src/drilldownMenu/drilldownMenu.js
@@ -331,7 +331,6 @@ angular.module('mm.foundation.drilldownMenu', [])
         function onClickOpen(event) {
             drilldownMenu.drilldownMenuApi.show($element);
             event.stopImmediatePropagation();
-            event.preventDefault();
         }
         parent.on('click', onClickOpen);
 

--- a/src/drilldownMenu/drilldownMenu.js
+++ b/src/drilldownMenu/drilldownMenu.js
@@ -1,8 +1,12 @@
 angular.module('mm.foundation.drilldownMenu', [])
-.directive('drilldownMenu', ($compile, $timeout) => {
+.directive('drilldownMenu', ($compile, $timeout, $window) => {
     'ngInject';
+    const EVENT_BASE = 'mm.foundation.drilldownMenu';
+
     return {
-        bindToController: {},
+        bindToController: {
+            drilldownMenuApi: '=?',
+        },
         scope: {},
         restrict: 'A',
         controllerAs: 'vm',
@@ -13,12 +17,27 @@ angular.module('mm.foundation.drilldownMenu', [])
             vm.maxHeight = -1;
             vm.maxWidth = -1;
             vm.childMenus = [];
+            vm.generatedWrapper = null;
 
-            vm.openMenu = openMenu;
-            vm.closeMenu = closeMenu;
+            vm.drilldownMenuApi = {
+                show: openMenu,
+                hide: closeMenu,
+                hideAll: () => doCloseAll(vm),
+                resizeMenu: () => doResize(vm, $scope),
+
+                EVENTS: {
+                    resize: `resize.${EVENT_BASE}`,
+                    open: `open.${EVENT_BASE}`,
+                    hide: `hide.${EVENT_BASE}`,
+
+                    _emitEvent: emitEvent.bind(vm, $scope, $element),
+                },
+            };
+
             vm.reportChild = reportChild;
 
             vm.$postLink = $postLink;
+            vm.$onDestroy = $onDestroy;
         },
         link: dmLinkFunction,
     };
@@ -52,13 +71,12 @@ angular.module('mm.foundation.drilldownMenu', [])
              * Add a wrapper element to hide the overflowed menu items
              */
             const wrapper = '<div class="is-drilldown"></div>';
-            const elementWrapper = angular.element(wrapper);
-            $element.wrap(elementWrapper);
+            drilldownMenu.generatedWrapper = angular.element(wrapper);
+            $element.wrap(drilldownMenu.generatedWrapper);
         }
 
         /**
-         * Compile the element so that angular knows about it and will apply the
-         * the li directive below
+         * Store the root element so we have access to it elsewhere
          */
         drilldownMenu.$element = $element;
     }
@@ -71,6 +89,8 @@ angular.module('mm.foundation.drilldownMenu', [])
     function openMenu(ulChild) {
         ulChild.removeClass('invisible');
         ulChild.addClass('is-active');
+
+        this.EVENTS._emitEvent(this.EVENTS.open, ulChild);
     }
 
     /**
@@ -84,6 +104,20 @@ angular.module('mm.foundation.drilldownMenu', [])
             ulParent.removeClass('is-active is-closing');
             ulParent.addClass('invisible');
         });
+
+        this.EVENTS._emitEvent(this.EVENTS.hide, ulParent);
+    }
+
+    /**
+     * Returns to the top level in the menu.
+     */
+    function doCloseAll(vm) {
+        for (let i = 0; i < vm.childMenus.length; ++i) {
+            const child = vm.childMenus[i];
+            if (child.hasClass('is-active')) {
+                vm.drilldownMenuApi.hide(child);
+            }
+        }
     }
 
     /**
@@ -97,12 +131,24 @@ angular.module('mm.foundation.drilldownMenu', [])
     }
 
     /**
-     * Called when everything is finished linking.  We use this to calculate the
-     * height of the sub mnenus so that we can size the wrapper div appropriately
-     * so that the largest submenu is visible.
+     * Does a resize of the control based on the dimensions of the largest
+     * submenu (or the top level if its the biggest(.
+     *
+     * @param {Object} vm   - the view model for this directive
      */
-    function $postLink() {
-        const vm = this;
+    function doResize(vm) {
+        const parent = vm.$element.parent();
+
+        /**
+         * Reset any hardcoded styles so the children can achieve their natural size
+         */
+        parent.css({
+            'max-width': 'none',
+            'min-height': 'none',
+        });
+        vm.maxHeight = -1;
+        vm.maxWidth = -1;
+
         /**
          * Calculate the height of each menu and work out the maxes.
          */
@@ -123,15 +169,83 @@ angular.module('mm.foundation.drilldownMenu', [])
             maxWidth: `${vm.maxWidth}px`,
         };
 
-        const parent = vm.$element.parent();
-
         parent.css(css);
+
+        /**
+         * Emit an event to say we have been resized
+         */
+        vm.drilldownMenuApi.EVENTS._emitEvent(vm.drilldownMenuApi.EVENTS.resize);
+    }
+
+    /**
+     * Called when everything is finished linking.  We use this to calculate the
+     * height of the sub mnenus so that we can size the wrapper div appropriately
+     * so that the largest submenu is visible.
+     */
+    function $postLink() {
+        const vm = this;
+
+        /**
+         * Set the sizes the first time
+         */
+        doResize(vm);
+
+        /**
+         * Handle window resizes and do it whenever the window size changes.
+         */
+        angular.element($window).on('resize', vm.drilldownMenuApi.resizeMenu);
+    }
+
+    /**
+     * Called when we are being destroyed.
+     *  We use this to do cleanup of the various changes we made
+     */
+    function $onDestroy() {
+        const vm = this;
+
+        /**
+         * Remove the resize event handler
+         */
+        angular.element($window).off('resize', vm.drilldownMenuApi.resizeMenu);
+
+        /**
+         * Find out if we need to remove the generated wrapper element
+         */
+        if (vm.generatedWrapper) {
+            delete vm.generatedWrapper;
+        }
+
+        /**
+         * Cleanup the API functions as they hold the controller by context
+         * and stop the controller deleting properly
+         */
+        delete vm.drilldownMenuApi.hideAll;
+        delete vm.drilldownMenuApi.resizeMenu;
+        delete vm.drilldownMenuApi.EVENTS._emitEvent;
+        vm.drilldownMenuApi = {};
+    }
+
+    /**
+     * Wrapper for $emit to simplify including the base element to identify
+     * the source of our emits.
+     *
+     * @param {Object} $scope               - The scope
+     * @param {angular.element} $element    - The element at the top of the menu
+     * @param {string} name                 - The name of the event to emit
+     * @param {...*} args                   - optional list of arguments to pass on
+     */
+    function emitEvent($scope, $element, name, ...args) {
+        //
+        // Add our root element as the first extra argument
+        //
+        const newArgs = [$element].concat(args);
+        $scope.$emit(name, ...newArgs);
     }
 })
 .directive('ul', ($compile) => {
     'ngInject';
     return {
-        require: '?^^drilldownMenu',  // Must be in an ancestor UL, not *this* UL
+        require: '?^^drilldownMenu', // Must be in an ancestor UL, not *this* UL
         restrict: 'E',
         link: ulLinkFunction,
     };
@@ -158,6 +272,7 @@ angular.module('mm.foundation.drilldownMenu', [])
          * Check if the dom already contains a "back" link with the right class
          */
         let elementBack = null;
+        let generatedBack = false;
         const children = $element.children();
         for (let i = 0; i < children.length; ++i) {
             const elementChild = angular.element(children[i]);
@@ -173,13 +288,13 @@ angular.module('mm.foundation.drilldownMenu', [])
             /**
              * No existing one, so add in the automatic `back` element
              */
+            generatedBack = true;
             const backButton = '<li class="js-drilldown-back"><a tabindex="0">Back</a></li>';
             elementBack = angular.element(backButton);
             $element.prepend(elementBack);
 
             /**
-             * Compile the element so that angular knows about it and will apply the
-             * the li directive below
+             * Compile the element so that angular knows about it
              */
             $compile(elementBack)($scope);
         }
@@ -187,11 +302,12 @@ angular.module('mm.foundation.drilldownMenu', [])
         /**
          * Add the event handler to the `back` element (whether added or existing)
          */
-        elementBack.on('click', (event) => {
-            drilldownMenu.closeMenu($element);
+        function onClickBack(event) {
+            drilldownMenu.drilldownMenuApi.hide($element);
             event.stopImmediatePropagation();
             event.preventDefault();
-        });
+        }
+        elementBack.on('click', onClickBack);
 
         /**
          * Report this element to the controller for tracking
@@ -201,21 +317,49 @@ angular.module('mm.foundation.drilldownMenu', [])
         /**
          * Now set the styles
          */
-        $element.addClass(
-            'menu vertical nested submenu is-drilldown-submenu ' +
-            'drilldown-submenu-cover-previous invisible'
-        );
+        const elementClasses =
+            'vertical nested submenu is-drilldown-submenu ' +
+            'drilldown-submenu-cover-previous invisible';
+        $element.addClass(elementClasses);
 
         /**
          * Find the parent LI, and set the event handler to open this level
          */
         const parent = $element.parent();
         parent.addClass('is-drilldown-submenu-parent');
-        parent.on('click', (event) => {
-            drilldownMenu.openMenu($element);
-            // $element.attr('data-is-click', 'true');
+
+        function onClickOpen(event) {
+            drilldownMenu.drilldownMenuApi.show($element);
             event.stopImmediatePropagation();
             event.preventDefault();
+        }
+        parent.on('click', onClickOpen);
+
+        /**
+         * Handler for $destroy event
+         */
+        $scope.$on('$destroy', () => {
+            /**
+             * Remove the open event handler from our parent.
+             */
+            parent.off('click', onClickOpen);
+
+            /**
+             * Remove the back event handler
+             */
+            elementBack.off('click', onClickBack);
+
+            /**
+             * Remove any back element we dynamically added in
+             */
+            if (generatedBack) {
+                elementBack.remove();
+            }
+
+            /**
+             * Remove the classes we added to the element
+             */
+            $element.removeClass(elementClasses);
         });
     }
 });


### PR DESCRIPTION
This update adds 3 key updates to the existing drilldownMenu:
- automatic resizing when the viewport is resized.
- an API to programmatically control some features.
- a set of events, emitted as appropriate.

Automatic resizing was needed because the component only set its sizing
when it was initialised.  If the size of the screen became narrower (e.g.
landscape to portrait on a phone), the menus could easily be too large
for the initial area.

The API provides methods to resize and open and close submenus.  The
resize() method is particularly important in cases where the menu is
dynamically shown or hidden with ng-show as this can lead to a 0-size
component.  See the updated readme for details.

There are also a few events that are emitted to allow parent controllers
etc. to be notified. See the update readme for details.

Finally, this revision also fixes some memory leaks that happened when
the component was destroyed (e.g. via ng-if).

Test Plan:
- Ensure the unit tests still run and pass

- Test the API functions through the newly added demo section and
  ensure they affect the component as appropriate.
- Test the events are correctly emitted, both when the condition is
  triggered by normal usage, and when triggered by the API
- Test the control doesn't leak when used with ng-if (replacing the ng-show
  in the API demo section).
- Check the above works on:
  - Windows Chrome, Firefox, Edge, and IE 11
  - iOS Safari