### PR TITLE
fix(drilldownMenu): Move API initialisation to $onInit()

### DIFF
--- a/src/drilldownMenu/drilldownMenu.js
+++ b/src/drilldownMenu/drilldownMenu.js
@@ -19,23 +19,9 @@ angular.module('mm.foundation.drilldownMenu', [])
             vm.childMenus = [];
             vm.generatedWrapper = null;
 
-            vm.drilldownMenuApi = {
-                show: openMenu,
-                hide: closeMenu,
-                hideAll: () => doCloseAll(vm),
-                resizeMenu: () => doResize(vm, $scope),
-
-                EVENTS: {
-                    resize: `resize.${EVENT_BASE}`,
-                    open: `open.${EVENT_BASE}`,
-                    hide: `hide.${EVENT_BASE}`,
-
-                    _emitEvent: emitEvent.bind(vm, $scope, $element),
-                },
-            };
-
             vm.reportChild = reportChild;
 
+            vm.$onInit = $onInit.bind(vm, $scope, $element);
             vm.$postLink = $postLink;
             vm.$onDestroy = $onDestroy;
         },
@@ -178,6 +164,35 @@ angular.module('mm.foundation.drilldownMenu', [])
     }
 
     /**
+     * Called to initialise the directive.
+     * We use this to setup to the API once the binding has been initialised
+     *
+     * @param {Object} $scope   - the current scope
+     * @param {Object} $element - the element
+     */
+    function $onInit($scope, $element) {
+        const vm = this;
+        vm.drilldownMenuApi = {
+            show: openMenu,
+            hide: closeMenu,
+            hideAll: function hideAll() {
+                return doCloseAll(vm);
+            },
+            resizeMenu: function resizeMenu() {
+                return doResize(vm, $scope);
+            },
+
+            EVENTS: {
+                resize: `resize.${EVENT_BASE}`,
+                open: `open.${EVENT_BASE}`,
+                hide: `hide.${EVENT_BASE}`,
+
+                _emitEvent: emitEvent.bind(vm, $scope, $element),
+            },
+        };
+    }
+
+    /**
      * Called when everything is finished linking.  We use this to calculate the
      * height of the sub mnenus so that we can size the wrapper div appropriately
      * so that the largest submenu is visible.
@@ -223,6 +238,8 @@ angular.module('mm.foundation.drilldownMenu', [])
         delete vm.drilldownMenuApi.resizeMenu;
         delete vm.drilldownMenuApi.EVENTS._emitEvent;
         vm.drilldownMenuApi = {};
+
+        delete vm.$onInit;
     }
 
     /**


### PR DESCRIPTION
The API was being initialised in the main controller function, but
it should have been set in `$onInit()`.  In some cases the api was
being overwritten by the value from the parent scope, rather than
the other way round.

Not sure exactly why this didn't happen in the demo code, but did
happen in my actual app.  In any case, $onInit() is the correct place
as it is run after bindings have been initialised.

Test Plan:
- Check this still works in the demo page.
- Check this works in my own application.