### PR TITLE
feat(general): Support content security policy in the local serving of the demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ We are always looking for the quality contributions! Please check the [CONTRIBUT
 
 Not specifying any modules will build all modules. Check the `gulpfile.js` file for other tasks that are defined for this project.
 
+#### Testing with Content Security Policy
+Add the `--csp` option (e.g. `gulp --csp`) to add Content Security Policy headers to the files
+served from the local test server.
+
+Content Security Policy restricts where scripts, styles, etc. can be sourced from to improve
+protection from XSS attacks. Most notably it usually prevents use of inline scripts and styles, and
+therefore directives should be careful not to use the blocked features.
+
 #### TDD
 * Run test: `gulp watch`
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,7 @@ var eslint = require('gulp-eslint');
 var browserSync = require('browser-sync').create();
 var history = require('connect-history-api-fallback');
 var semver = require('semver');
+const helmetCsp = require('helmet-csp');
 
 var base = path.join(__dirname, 'src');
 var watchedFiles = [
@@ -75,6 +76,46 @@ var uglifySettings = {
         join_vars: true,
         drop_console: true
     }
+};
+
+/**
+ * Optional enabling of Content-Security Policy for the demo page.
+ * Use --csp to enable CSP headers.
+ */
+let enableCSP = false;
+if (argv.csp) {
+    enableCSP = true;
+}
+
+/**
+ * Helmet options for content-security-policy
+ */
+const cspOptions = {
+    directives: {
+        defaultSrc: [
+            '\'self\'',
+            'http://cdnjs.cloudflare.com',  // Fastclick, es6 shim, etc.
+            'http://ajax.googleapis.com',   // Angular JS etc.
+        ],
+
+        scriptSrc: [
+            '\'self\'',
+            'http://cdnjs.cloudflare.com',
+            'http://ajax.googleapis.com',
+
+            //
+            // Browsersync injected script is allows via the hash.
+            // This WILL need to be updated when browsersync is updated
+            //
+            '\'sha256-GKWAMtgBzlCzmucztJIeDl/kD0MKNqAT5HDcFIff2+A=\'', // Browsersync injected
+        ],
+
+        connectSrc: [
+            'ws://localhost:3000',  // Browsersync socket connection
+            'http://localhost:3000',  // Browsersync connection
+        ],
+    },
+    reportOnly: false,
 };
 
 var pkg = require('./package.json');
@@ -279,7 +320,7 @@ gulp.task('changelog', () => {
         .pipe(gulp.dest('./'));
 });
 
-gulp.task('demo', () => {
+gulp.task('demo', ['demojs'], () => {
     var modules = findModules();
     var demoModules = modules.filter((module) => {
         return module.docs.md && module.docs.js && module.docs.html;
@@ -320,6 +361,18 @@ gulp.task('demo', () => {
     return merge(assets, html, css).pipe(gulp.dest('./dist'));
 });
 
+gulp.task('demojs', () => {
+    const modules = findModules();
+    const demoModules = modules.filter((module) => {
+        return module.docs.md && module.docs.js && module.docs.html;
+    });
+
+    return gulp.src('./misc/demo/index.js')
+        .pipe(template({
+            demoModules,
+        }))
+        .pipe(gulp.dest('./dist'));
+});
 
 // Test
 gulp.task('test-current', (done) => {
@@ -429,11 +482,20 @@ gulp.task('release', (done) => {
 });
 
 gulp.task('server:connect', () => {
+    //
+    // Enable the middleware.
+    // CSP is included only if the --csp flag is passed on the command line.
+    //
+    const middleware = [history()];
+    if (enableCSP) {
+        middleware.push(helmetCsp(cspOptions));
+    }
+
     browserSync.init({
         // port: 8080,
         server: './dist/',
         // browser: ["google-chrome"/*, "firefox"*/],
-        middleware: [ history() ]
+        middleware,
     });
 });
 

--- a/misc/demo/index.html
+++ b/misc/demo/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" ng-app="foundationDemoApp" id="top">
-<head>
+<head ng-csp>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
@@ -19,11 +19,17 @@
   <script src="angular-foundation.js"></script>
   <script src="assets/plunker.js"></script>
   <script src="assets/app.js"></script>
+
+  <!-- Concatenated scripts from the module demo folders -->
+  <script src="index.js"></script>
+
   <link href="https://cdnjs.cloudflare.com/ajax/libs/foundation/<%= fdversion %>/css/foundation-float.css" rel="stylesheet"/>
   <!-- <link href="//cdnjs.cloudflare.com/ajax/libs/foundation/<%= fdversion %>/css/foundation-float.min.css" rel="stylesheet"/> -->
+  <link href="//ajax.googleapis.com/ajax/libs/angularjs/<%= ngversion %>/angular-csp.css" rel="stylesheet"/>
   <link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/<%= faversion %>/css/font-awesome.min.css" rel="stylesheet"/>
   <link rel="stylesheet" href="assets/rainbow.css"/>
   <link rel="stylesheet" href="assets/demo.css"/>
+
   <link rel="author" href="https://github.com/circlingthesun/angular-foundation-6/graphs/contributors">
 </head>
 <body class="ng-cloak" ng-controller="MainCtrl">
@@ -163,7 +169,6 @@
                       </div>
                     </div>
                   </section>
-                  <script><%= module.docs.js %></script>
                 <% }); %>
                 <section id="animations">
                   <div class="page-header">

--- a/misc/demo/index.js
+++ b/misc/demo/index.js
@@ -1,0 +1,3 @@
+<% demoModules.forEach(function(module) { %>
+    <%= module.docs.js %>
+<% }); %>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp-sass": "^2.2.0",
     "gulp-template": "^3.1.0",
     "gulp-uglify": "^1.5.1",
+    "helmet-csp": "^2.5.1",
     "highlight.js": "^9.2.0",
     "jasmine-core": "^2.4.1",
     "jspm": "^0.16.19",


### PR DESCRIPTION
## Summary

Many of the directives and directive demos do not work with CSP enabled.  This revision adds support for local testing of the directives with CSP enabled to help resolve that problem.

- Adds `--csp` flag to gulp to send CSP headers via the browsersync server
- Adds [`ng-csp`](https://code.angularjs.org/1.6.5/docs/api/ng/directive/ngCsp) and related css for Angular's internal csp support.
- Updates the demo page generation to write the demo js to an `index.js` file rather than inline in the demo page to avoid inline script issues

⚠️ WARNING: most directives and/or demos DO NOT currently work with CSP enabled!
⚠️ WARNING: the new `index.js` must also be copied to gh_pages.  Looks like gulp publish will do that, but worth checking!

## Details

[Content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is a useful security layer to protect applications against XSS and other attacks.

It usually prevents use of inline scripts and inline styles, which up to now have been used in a number of places. So its important to test with CSP enabled to ensure the directives are usable in CSP secured pages.

This revision makes it easy to test by providing a `--csp` flag that will send a minimal set of content-security-policy headers to the browser as part of serving the demo page. Ideally CSP would be enabled by default, but too many of the directives and demos would break at this time.

The configured policy does not include `unsafe-inline` (for obvious reasons) so this change also had to remove the inlining of scripts into the demo page.  This is replaced by generating an `index.js` file
and sourcing that in the index.html instead (which is secure as it comes from `'self'`).

The csp support comes from [helmet-csp](https://helmetjs.github.io/docs/csp/), a well regarded security middleware.

## Test Plan
- Run `gulp`
   - Check all unit test still run and pass
  - Check the demo page is generated and shows in the browser
  - Check the response headers DO NOT include content-security-policy
  - Check all directives continue to work as before
  - Check no errors are shown in the console

- Run `gulp --csp`
  - Check all unit test still run and pass
  - Check the demo page is generated and shows in the browser
  - Check the response headers DO include content-security-policy
  - Check at least some directives continue to work
  - Check all fonts and external scripts are allowed to be loaded
  - Check the console shows CSP-related errors for the directives or
   demos that don't work.