### PR TITLE
fix(dropdownMenu): Fix dropdownMenu demo to work with CSP

### DIFF
--- a/src/dropdownMenu/docs/demo.html
+++ b/src/dropdownMenu/docs/demo.html
@@ -45,7 +45,7 @@
   <!-- Vertical -->
   <h2>Vertical menu</h2>
 
-  <ul class="vertical dropdown menu" dropdown-menu style="max-width: 300px;">
+  <ul class="vertical dropdown menu mm-foundation-6-demo-dropdown-menu" dropdown-menu>
     <li>
       <a href="#" tabindex="0">Item 1</a>
       <ul class="menu">

--- a/src/dropdownMenu/docs/demo.scss
+++ b/src/dropdownMenu/docs/demo.scss
@@ -1,0 +1,6 @@
+.mm-foundation-6-demo-dropdown-menu {
+    //
+    // For demo purposes, limit this to 300px wide
+    //
+    max-width: 300px;
+}


### PR DESCRIPTION
## Summary
The dropdownMenu demo html included inline styles which breaks when served with CSP enabled.

This revision fixes it by:
- Updating the gulpfile to include (optional) per-module scss
- Removing the inline style and replacing it with a class, styled in a module-specific scss file.

## Test Plan
- run `gulp --csp --modules=dropdownMenu,modal` and check:
  - all unit tests run and pass
  - no CSP errors are reported
  - the vertical menu is limited to max 300px wide
  - that changes to the scss file triggers the watcher