### PR TITLE
fix(build): update gulp-sass to latest (3.1.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-ngdocs": "^0.2.13",
     "gulp-postcss": "^6.1.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "^3.1.0",
     "gulp-template": "^3.1.0",
     "gulp-uglify": "^1.5.1",
     "helmet-csp": "^2.5.1",


### PR DESCRIPTION
This revision updates gulp-sass to the latest version for easier install on higher node versions. 

## Details
`gulp-sass` 2.x ends up requiring `lib-sass` 3.13.1 which doesn't have a pre-built binaries
for node > 4.x.  E.g. see https://github.com/sass/node-sass/issues/2017. 

Upgrading to gulp-sass 3.x pulls in lib-sass 4.x which does have binaries.  This makes installation a lot easier, particularly on windows where configuration of a compiler to compile your own binaries is complicated.

## Backwards Compatibility
This shouldn't cause any backwards compatibility issues: The last comment on the above issue is:

> It's worth noting there are no breaking changes between gulp-sass 2 and 3 so upgrade should be painless.

## Test Plan
- run `gulp` and make sure all unit tests run and pass, and the demo pages comes up with everything styled correctly.