### PR TITLE
fix(demo): Fix CSP issues in demos for progressbar and rating directives

### DIFF
--- a/src/progressbar/docs/demo.html
+++ b/src/progressbar/docs/demo.html
@@ -1,11 +1,4 @@
 <div ng-controller="ProgressDemoCtrl">
-    <style>
-      .progress .progress-meter {
-        -webkit-transition: width 1s ease-out;
-        transition: width 1s ease-out;
-      }
-    </style>
-
     <h3>Static</h3>
     <div class="row">
         <div class="columns small-4"><progressbar value="55"></progressbar></div>

--- a/src/progressbar/docs/demo.scss
+++ b/src/progressbar/docs/demo.scss
@@ -1,0 +1,4 @@
+.progress .progress-meter {
+    -webkit-transition: width 1s ease-out;
+    transition: width 1s ease-out;
+}

--- a/src/progressbar/docs/readme.md
+++ b/src/progressbar/docs/readme.md
@@ -6,7 +6,7 @@ It supports multiple (stacked) bars into the same `<progress>` element or a sing
 
 #### `<progressbar>` ####
 
- * `value` <i class="fa-eye"></i>
+ * `value` <i class="fa fa-eye"></i>
  	:
  	The current value of progress completed.
 

--- a/src/rating/docs/demo.html
+++ b/src/rating/docs/demo.html
@@ -3,7 +3,7 @@
     <rating value="rate" max="max" readonly="isReadonly" on-hover="hoveringOver(value)" on-leave="overStar = null"></rating>
     <span class="label" ng-class="{'label-warning': percent<30, 'label-info': percent>=30 && percent<70, 'label-success': percent>=70}" ng-show="overStar && !isReadonly">{{percent}}%</span>
 
-    <pre style="margin:15px 0;">Rate: <b>{{rate}}</b> - Readonly is: <i>{{isReadonly}}</i> - Hovering over: <b>{{overStar || "none"}}</b></pre>
+    <pre class="mm-foundation-rating-demo-pre">Rate: <b>{{rate}}</b> - Readonly is: <i>{{isReadonly}}</i> - Hovering over: <b>{{overStar || "none"}}</b></pre>
 
     <button class="button small alert" ng-click="rate = 0" ng-disabled="isReadonly">Clear</button>
     <button class="button small" ng-click="isReadonly = ! isReadonly">Toggle Readonly</button>

--- a/src/rating/docs/docs.scss
+++ b/src/rating/docs/docs.scss
@@ -1,0 +1,3 @@
+.mm-foundation-rating-demo-pre {
+    margin:15px 0;
+}


### PR DESCRIPTION
In both cases this was simply moving some inline styles to a local demo.scss file.
Also fixed a minor error in the progressbar readme that stopped an icon showing up.

## Test Plan:
- run `gulp --csp` and check there are no more CSP errors for those directives
- check the *eye* icon shows up in the progressbar section.