### PR TITLE
fix(tooltip): improve tooltip positioning; close on background click

### DIFF
--- a/src/tooltip/test/tooltip.spec.js
+++ b/src/tooltip/test/tooltip.spec.js
@@ -30,6 +30,8 @@ describe('tooltip', function() {
 
         scope = $rootScope;
         $compile(elmBody)(scope);
+        //place element in test body so spacing calculations can be done
+        angular.element(document).find('body').append(elmBody); 
         scope.$digest();
         elm = elmBody.find('span');
         elmScope = elm.scope();
@@ -120,7 +122,7 @@ describe('tooltip', function() {
         expect(elm.attr('alt')).toBe(scope.alt);
 
         ttScope = angular.element(elmBody.children()[1]).isolateScope();
-        expect(ttScope.placement).toBe('top');
+        expect(ttScope.placement).toBe('bottom'); // no space above
         expect(ttScope.content).toBe(scope.tooltipMsg);
 
         elm.triggerHandler('mouseout');
@@ -129,7 +131,7 @@ describe('tooltip', function() {
         elm.triggerHandler('mouseover');
 
         ttScope = angular.element(elmBody.children()[1]).isolateScope();
-        expect(ttScope.placement).toBe('top');
+        expect(ttScope.placement).toBe('bottom');
         expect(ttScope.content).toBe(scope.tooltipMsg);
     }));
 


### PR DESCRIPTION
Some work towards improving tooltip positioning, and adding close on background click behaviour.

As an aside, we've been using angular 1.6 internally with this library (mostly modals, tabs, tooltips, dropdowns) and it's caused no trouble.